### PR TITLE
SQLite driver installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM zabbix/zabbix-proxy-sqlite3:alpine-3.4-latest
+
+# Build and install SQLite unixODBC driver
+RUN apk update && \
+    apk add build-base sqlite-dev unixodbc-dev && \
+    cd /tmp/ && \
+    wget http://www.ch-werner.de/sqliteodbc/sqliteodbc-0.9996.tar.gz && \
+    tar zxvf sqliteodbc-0.9996.tar.gz && \
+    cd sqliteodbc-0.9996 && \
+    ./configure && \
+    make && \
+    make install && \
+    rm -fr /tmp/sqliteodbc-0.9996 && \
+    apk del --purge build-base sqlite-dev unixodbc-dev && \
+    rm -rf /var/cache/apk/*
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # zabbix-proxy-sqlite3
-Zabbix proxy with SQLite3 database support
+Zabbix proxy docker container with SQLite3 database support
+
+This container is based on the official [zabbix/zabbix-proxy-sqlite3](https://hub.docker.com/r/zabbix/zabbix-proxy-sqlite3/) docker container,
+with the following modifications:
+
+* SQLite ODBC driver pre-built and installed in the container
+
+Only Alpine version is supported so far.


### PR DESCRIPTION
A version of proxy container that contains pre-built SQLite driver. Tested and working, published as a public container at https://hub.docker.com/r/zabbix/zabbix-proxy-sqlite3/.