### PR TITLE
Iiscrum 1328 python and requests to proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM zabbix/zabbix-proxy-sqlite3:ubuntu-4.4-latest
 
+USER root
+
 # Build and install SQLite unixODBC driver, Python and requests library
 RUN apt-get update && \
     apt-get install -y build-essential sqlite3 libsqlite3-dev unixodbc-dev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ RUN apt-get update && \
     ln -s /usr/bin/python3 python && \
     pip3 install --upgrade --no-cache-dir requests && \
     rm -rf /var/cache/apk/*
- 
-
+	
+USER zabbix

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM zabbix/zabbix-proxy-sqlite3:ubuntu-4.4-latest
 
-# Build and install SQLite unixODBC driver
+# Build and install SQLite unixODBC driver, Python and requests library
 RUN apt-get update && \
     apt-get install -y build-essential sqlite3 libsqlite3-dev unixodbc-dev && \
     cd /tmp/ && \
@@ -13,12 +13,11 @@ RUN apt-get update && \
     make install && \
     rm -fr /tmp/sqliteodbc-0.9996 && \
     apt-get purge -y build-essential sqlite3 libsqlite3-dev unixodbc-dev && \
-    rm -rf /var/cache/apk/*
- 
-# Install Python, pip and requests library 
-RUN apt-get update && \
-    apt-get install -y python3-pip python3-dev  && \
+	
+	apt-get install -y python3-pip python3  && \
     cd /usr/local/bin && \
     ln -s /usr/bin/python3 python && \
     pip3 install --upgrade --no-cache-dir requests && \
-    apt-get clean
+    rm -rf /var/cache/apk/*
+ 
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,12 @@ RUN apt-get update && \
     rm -fr /tmp/sqliteodbc-0.9996 && \
     apt-get purge -y build-essential sqlite3 libsqlite3-dev unixodbc-dev && \
     rm -rf /var/cache/apk/*
-    
+ 
+# Install Python, pip and requests library 
+RUN apt-get update && \
+    apt-get install -y python3-pip python3-dev  && \
+    cd /usr/local/bin && \
+    ln -s /usr/bin/python3 python && \
+    pip3 install --upgrade --no-cache-dir pip && \
+    pip3 install --upgrade --no-cache-dir requests && \
+    apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     make install && \
     rm -fr /tmp/sqliteodbc-0.9996 && \
     apt-get purge -y build-essential sqlite3 libsqlite3-dev unixodbc-dev && \
-	
-	apt-get install -y python3-pip python3  && \
+
+    apt-get install -y python3-pip python3  && \
     cd /usr/local/bin && \
     ln -s /usr/bin/python3 python && \
     pip3 install --upgrade --no-cache-dir requests && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,5 @@ RUN apt-get update && \
     apt-get install -y python3-pip python3-dev  && \
     cd /usr/local/bin && \
     ln -s /usr/bin/python3 python && \
-    pip3 install --upgrade --no-cache-dir pip && \
     pip3 install --upgrade --no-cache-dir requests && \
     apt-get clean

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ This container is based on the official [zabbix/zabbix-proxy-sqlite3](https://hu
 with the following modifications:
 
 * SQLite ODBC driver pre-built and installed in the container
+* Python3 installation with requests library 
 
 Only Alpine version is supported so far.


### PR DESCRIPTION
I added the "USER root" line because the container failed to build without it even when I reverted to the original ubuntu-4.4-latest branch: https://hub.docker.com/repository/docker/digiapulssi/zabbix-proxy-sqlite3/builds

Fix found here https://github.com/WASdev/ci.docker/issues/194